### PR TITLE
Added python-dotenv to requirements.txt and .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Adding .env to Avoid accidental .env checkin
+.env
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ six==1.12.0
 SQLAlchemy==1.2.16
 urllib3==1.24.1
 Werkzeug==0.14.1
+python-dotenv


### PR DESCRIPTION

1. Requirements.txt was missing python-dotenv to get/set the .env
2. Add .env to .gitignore to avoid accidental checkin of .env with secrets
