### PR TITLE
Corrected Issues with requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 alembic==1.0.6
 certifi==2018.11.29
-cffi==1.11.5
+cffi==1.14.5
 chardet==3.0.4
 Click==7.0
 Flask==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ Jinja2==2.10.1
 Mako==1.0.7
 MarkupSafe==1.1.0
 misaka==2.1.1
-psycopg2==2.7.3.2
+psycopg2==2.8.6
 pycparser==2.19
 python-dotenv==0.10.1
 python-editor==1.0.3


### PR DESCRIPTION
`$ pip install -r requirements.txt`

Had issues installing mentioned modules in Windows machine with the cffi and psycopg2 versions. Changing them to the current latest version removes the issues and lead to successful execution of the file "requirements.txt"
[https://pypi.org/project/cffi/1.14.5/](url)
[https://pypi.org/project/psycopg2/2.8.6/](url)
#26 